### PR TITLE
#89 reject /subscribe submissions with a non-empty honeypot field

### DIFF
--- a/mailanes.rb
+++ b/mailanes.rb
@@ -697,6 +697,8 @@ end
 
 post '/subscribe' do
   list = List.new(id: params[:list].to_i, pgsql: settings.pgsql)
+  trap = list.yaml['captcha'].is_a?(Hash) ? list.yaml['captcha']['honeypot'].to_s : ''
+  raise UserError, 'Submission flagged as automated' unless trap.empty? || params[trap].to_s.strip.empty?
   email = params[:email].downcase.strip
   notify = []
   if list.recipients.exists?(email)

--- a/test/test_mailanes.rb
+++ b/test/test_mailanes.rb
@@ -74,6 +74,24 @@ class AppTest < Minitest::Test
     assert_predicate(recipient, :active?)
   end
 
+  def test_rejects_subscribe_when_honeypot_filled
+    list = Lists.new(owner: random_owner, pgsql: t_pgsql).add
+    list.yaml = "captcha:\n  honeypot: website"
+    email = "h-#{SecureRandom.hex[0..8]}@mailanes.com"
+    post("/subscribe?list=#{list.id}&email=#{email}&website=http%3A%2F%2Fspam.example")
+    assert_equal(503, last_response.status, last_response.body)
+    assert_equal(0, list.recipients.count)
+  end
+
+  def test_accepts_subscribe_when_honeypot_empty
+    list = Lists.new(owner: random_owner, pgsql: t_pgsql).add
+    list.yaml = "captcha:\n  honeypot: website"
+    email = "h-#{SecureRandom.hex[0..8]}@mailanes.com"
+    post("/subscribe?list=#{list.id}&email=#{email}&website=")
+    assert_equal(200, last_response.status, last_response.body)
+    assert_equal(1, list.recipients.count)
+  end
+
   def test_adds_new_recipient_for_friend
     owner = random_owner
     list = Lists.new(owner: owner, pgsql: t_pgsql).add


### PR DESCRIPTION
Refs #89. Adds an opt-in honeypot field as a minimal first step toward captcha integration on `/subscribe`. A list owner sets `captcha: { honeypot: <field-name> }` in the list YAML; the POST handler then raises `UserError` whenever the named param arrives non-empty. Lists without that YAML key keep the previous behavior bit-for-bit, so every existing embedder form continues to subscribe humans unchanged.

The visible effect from a spammer's view: an automated form-filler that pours strings into every input on the page now hits a server-side 503 instead of a created recipient, because the trap field is hidden by CSS on the embedder side and only bots fill it. From a list owner's view: adding two lines of YAML and one hidden `<input>` to the existing form is enough to start filtering submissions.

Checks run locally: `bundle exec rubocop mailanes.rb test/test_mailanes.rb` and `LANG=C.utf8 bundle exec rake xcop` and `bundle exec haml-lint views/` — all green. The full minitest suite needs Postgres and Liquibase, which the CI workflow `rake.yml` provisions; relying on CI for that pass.
