### PR TITLE
#265 align rubocop TargetRubyVersion with CI Ruby 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'assets/**/*'
     - 'vendor/**/*'
   DisplayCopNames: true
-  TargetRubyVersion: 2.6.0
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
 plugins:

--- a/objects/recipients.rb
+++ b/objects/recipients.rb
@@ -14,7 +14,7 @@ require_relative 'user_error'
 # License:: MIT
 class Recipients
   # All emails have to match this
-  REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i.freeze
+  REGEX = /\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i
 
   def initialize(list:, pgsql:, hash: {})
     @list = list


### PR DESCRIPTION
Closes #265

`.rubocop.yml` pinned `TargetRubyVersion: 2.6.0` while `.github/workflows/rake.yml` runs the only CI matrix on Ruby 3.3 and the Gemfile no longer admits anything below Ruby 3. RuboCop therefore skipped every cop gated on Ruby 3.x and kept the 2.6 contract alive years after every gem stopped supporting it.

This raises `TargetRubyVersion` to `3.3`, matching the CI matrix and the runtime. The bump surfaces one previously-suppressed `Style/RedundantFreeze` offense at `objects/recipients.rb:17` (regex literals are immutable on Ruby 3+), which RuboCop autocorrects in place.

Verified locally with `LC_ALL=C.UTF-8 rake rubocop haml_lint xcop` against the patched tree: 47 files inspected, no RuboCop offenses; 25 files inspected, 0 haml-lint lints; 29 files inspected, xcop clean. The unit tests were not run locally because the suite depends on a live PostgreSQL instance; CI will run them.
